### PR TITLE
Change base layer to remove vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,11 @@
-FROM centos:7
-
-RUN yum install epel-release -y && \
-    yum install nginx gettext -y && \
-    yum clean all && \
-    mkdir -p /usr/share/nginx/html
+FROM nginx:mainline-alpine
 
 
 COPY docker-entrypoint.sh ./
 
 USER root
-RUN chmod 777 /docker-entrypoint.sh
-RUN chmod -R 777 /usr/share/nginx/html/
-RUN echo "nginx on CentOS7" > /usr/share/nginx/html/index.html
+RUN chmod 777 ./docker-entrypoint.sh
 RUN chmod 777 /run /var/log/nginx
-RUN chmod -R 777 /var/lib/nginx
 
 EXPOSE 8080
 


### PR DESCRIPTION
This PR fixes couple of dozens of vulnerabilities caused by the base layer (CentOS7) and very old version of Nginx.